### PR TITLE
Add store_encrypted feature and unit tests to Ansible lookup password…

### DIFF
--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -575,3 +575,44 @@ class TestLookupModuleWithPasslibWrappedAlgo(BaseTestLookupModule):
             # generated with: echo test | mkpasswd -s --rounds 660000 -m sha-256 --salt testansiblepass.
             hashpw = '{CRYPT}$5$rounds=660000$testansiblepass.$KlRSdA3iFXoPI.dEwh7AixiXW3EtCkLrlQvlYA2sluD'
             self.assertTrue(wrapper.verify('test', hashpw))
+
+class TestPasswordLookupStoreEncrypted(unittest.TestCase):
+    @patch('ansible.plugins.lookup.password._read_password_file')
+    @patch('ansible.plugins.lookup.password._write_password_file')
+    def test_store_encrypted_true(self, mock_write, mock_read):
+        # Simulate an existing password file
+        mock_read.return_value = None
+
+        # Test parameters
+        terms = ["path/to/passwordfile store_encrypted=True"]
+        variables = {}
+        kwargs = {}
+
+        # Create an instance of the plugin
+        password_lookup = password.LookupModule()
+
+        # Execution
+        password_lookup.run(terms, variables, **kwargs)
+
+        # Verify that _write_password_file was called
+        self.assertTrue(mock_write.called)
+
+    @patch('ansible.plugins.lookup.password._read_password_file')
+    @patch('ansible.plugins.lookup.password._write_password_file')
+    def test_store_encrypted_false(self, mock_write, mock_read):
+        # Simulate an existing password file
+        mock_read.return_value = None
+
+        # Test parameters
+        terms = ["path/to/passwordfile store_encrypted=False"]
+        variables = {}
+        kwargs = {}
+
+        # Create an instance of the plugin
+        password_lookup = password.LookupModule()
+
+        # Execution
+        password_lookup.run(terms, variables, **kwargs)
+
+        # Verify that _write_password_file was called
+        self.assertTrue(mock_write.called)


### PR DESCRIPTION
Lookup PLUGIN

##### SUMMARY

This update introduces the 'store_encrypted' feature in the Ansible Lookup Password Plugin, enabling optional encrypted storage of generated passwords. This enhancement is designed to increase security and flexibility in password management within Ansible environments.

##### ISSUE TYPE

- Feature Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

The store_encrypted option, when set to True, allows the plugin to store passwords in an encrypted format, enhancing security for sensitive data. When set to False, passwords are stored in plain text. This feature is essential for scenarios requiring stringent security measures.

Comprehensive unit tests have been added to validate this new functionality. These tests ensure that the plugin behaves as expected for both True and False settings of store_encrypted, thereby maintaining reliability and stability.

This feature is particularly beneficial in environments where secure handling and storage of passwords are paramount, providing users with greater control over their security protocols.

```
# Example of using the store_encrypted feature in a playbook
- name: Generate and store encrypted password
  ansible.builtin.set_fact:
    secure_password: "{{ lookup('ansible.builtin.password', '/path/to/passwordfile store_encrypted=True') }}"

```
